### PR TITLE
Switched to Release 4.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "breathe" %}
-{% set version = "4.2.0" %}
-{% set sha256 = "978eba211d8602122d58857d56ffa7dc454b2743402ad37b0fa05a22ba477c54" %}
+{% set version = "4.6.0" %}
+{% set sha256 = "9db2ba770f824da323b9ea3db0b98d613a4e0af094c82ccb0a82991da81b736a" %}
 
 package:
   name: {{ name|lower }}
@@ -47,3 +47,4 @@ about:
 extra:
   recipe-maintainers:
     - SylvainCorlay
+    - JohanMabille


### PR DESCRIPTION
@SylvainCorlay This updates the recipe with the last release of breathe. The current version (4.2.0) cannot render non-type template parameter and raises an error complaining about pending_xref. This bug is fixed in 4.6.0.

Also feel free to add me as a maintainer for this recipe (I already added myself in the meta.yaml)