### PR TITLE
Suggestion: Update sphinx pinnings

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - sphinx >=4.0,<6.0.0a
   run:
     - python >=3.6
-    - sphinx >=4.0,<6.0.0a
+    - sphinx >=4.0,<7
     - docutils >=0.12
     - Jinja2 >=2.7.3
     - MarkupSafe >=0.23

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python >=3.6
     - setuptools
     # Detects sphinx at build time
-    - sphinx >=4.0,<6.0.0a
+    - sphinx >=4.0,<7.0.0a
   run:
     - python >=3.6
     - sphinx >=4.0,<7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - sphinx >=4.0,<7.0.0a
   run:
     - python >=3.6
-    - sphinx >=4.0,<7
+    - sphinx >=4.0,<7.0.0a
     - docutils >=0.12
     - Jinja2 >=2.7.3
     - MarkupSafe >=0.23


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
As Breathe itself is now testing with Sphinx 6 (https://github.com/breathe-doc/breathe/commit/ef4e245804759d44ae54fc832b4d5155837f0720) we would like to suggest pinning the Sphinx version to `<7`. This would enable the build of the documentation with Sphinx 6 and newer version of Breathe.