### PR TITLE
Allow using latest Breathe with Sphinx 8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ About breathe-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/breathe-feedstock/blob/main/LICENSE.txt)
 
-Home: https://github.com/michaeljones/breathe
+Home: https://github.com/breathe-doc/breathe
 
 Package license: BSD-3-Clause
 
 Summary: An extension to reStructuredText and Sphinx to be able to read and render the Doxygen xml output.
 
-Development: https://github.com/michaeljones/breathe
+Development: https://github.com/breathe-doc/breathe
 
 Documentation: http://breathe.readthedocs.io/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
     - breathe
 
 about:
-  home: https://github.com/michaeljones/breathe
+  home: https://github.com/breathe-doc/breathe
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
@@ -52,7 +52,7 @@ about:
     people who enjoy using Sphinx but work with languages other than Python.
     The system relies on the Doxygen’s xml output.
   doc_url: http://breathe.readthedocs.io/
-  dev_url: https://github.com/michaeljones/breathe
+  dev_url: https://github.com/breathe-doc/breathe
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,10 @@ requirements:
     - python {{ python_min }}
     - setuptools
     # Detects sphinx at build time
-    - sphinx >=4.0,<7.2
+    - sphinx >=4.0,<9.0.0a0
   run:
     - python >={{ python_min }}
-    - sphinx >=4.0,<7.2
+    - sphinx >=4.0,<9.0.0a0
     - docutils >=0.12
     - Jinja2 >=2.7.3
     - MarkupSafe >=0.23


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Closes #63 

<!--
Please add any other relevant info below:
-->
[Breathe is testing against Sphinx 8 in their CI](https://github.com/breathe-doc/breathe/blob/main/.github/workflows/unit_tests.yml#L45), so this update should be safe.